### PR TITLE
chore: add GitHub automation workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,44 @@
+# .github/labeler.yml — actions/labeler v5 schema
+# Labels PRs based on changed files.
+# For release-drafter compatibility, see also: auto-label-pr.yml
+
+# ═══════════════════════════════════════════════════════════════════
+# File-based labels (auto-applied by actions/labeler)
+# ═══════════════════════════════════════════════════════════════════
+
+java:
+  - changed-files:
+      - any-glob-to-any-file: 'src/main/java/**'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file: 'src/test/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/workflows/**'
+      - any-glob-to-any-file: 'Jenkinsfile'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: 'pom.xml'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: '*.md'
+      - any-glob-to-any-file: 'src/doc/**'
+
+localization:
+  - changed-files:
+      - any-glob-to-any-file: 'src/main/resources/**/*.properties'
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: 'src/main/webapp/**'
+      - any-glob-to-any-file: 'src/main/resources/**/*.jelly'
+
+chore:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+      - any-glob-to-any-file: '.gitignore'
+      - any-glob-to-any-file: 'crowdin.yml'

--- a/.github/workflows/auto-approve-owner-prs.yml
+++ b/.github/workflows/auto-approve-owner-prs.yml
@@ -1,0 +1,32 @@
+# Auto-approve owner PRs that receive no review within 3 days.
+#
+# Uses the reusable action: https://github.com/mPokornyETM/auto-approve-stale-prs
+#
+# Countdown labels give reviewers clear visibility:
+#   Day 0 → merge-in-3-days-without-review
+#   Day 1 → merge-in-2-days-without-review
+#   Day 2 → merge-in-1-day-without-review
+#   Day 3 → approved + merged-without-review (auto-merge takes over)
+#
+# Only PRs authored by a repo OWNER or MEMBER are processed.
+# PRs that already have at least one approval are skipped.
+name: Auto-approve owner PRs
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # daily at 08:00 UTC
+  workflow_dispatch: # allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  countdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mPokornyETM/auto-approve-stale-prs@v1
+        with:
+          days-until-approve: '3'
+          author-associations: 'OWNER'
+          merge-method: 'squash'

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,149 @@
+# Auto-label PRs based on title, branch, and author association.
+# Adds release-drafter compatible labels for changelog generation.
+# Also adds auto-approve countdown label for owner/member PRs.
+name: Auto-label PR
+
+on:
+  # Use pull_request_target so the workflow has write permissions even for fork PRs.
+  # SECURITY: Do not check out or execute code from the PR in this workflow.
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label based on title and branch
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title.toLowerCase();
+            const branch = pr.head.ref.toLowerCase();
+            const author = pr.user.login;
+            const authorAssoc = pr.author_association;
+            const isDraft = pr.draft;
+            
+            const labelsToAdd = [];
+            const labelsToRemove = [];
+            
+            // Get current labels
+            const currentLabels = pr.labels.map(l => l.name);
+            
+            console.log(`PR #${pr.number}: "${pr.title}"`);
+            console.log(`  Branch: ${branch}`);
+            console.log(`  Author: ${author} (${authorAssoc})`);
+            console.log(`  Draft: ${isDraft}`);
+            console.log(`  Current labels: ${currentLabels.join(', ') || 'none'}`);
+            
+            // ═══════════════════════════════════════════════════════════════
+            // Release-drafter compatible labels based on title/branch
+            // ═══════════════════════════════════════════════════════════════
+            
+            // Breaking changes
+            if (title.includes('breaking') || title.includes('!:') || branch.startsWith('breaking/')) {
+              labelsToAdd.push('breaking');
+            }
+            
+            // Major enhancements
+            if (title.includes('major') && (title.includes('feat') || title.includes('enhancement'))) {
+              labelsToAdd.push('major-enhancement');
+            }
+            
+            // Major bugs
+            if (title.includes('major') && (title.includes('fix') || title.includes('bug'))) {
+              labelsToAdd.push('major-bug');
+            }
+            
+            // Removed/Deprecated
+            if (title.includes('remove') || title.includes('deprecat')) {
+              if (title.includes('deprecat')) {
+                labelsToAdd.push('deprecated');
+              } else {
+                labelsToAdd.push('removed');
+              }
+            }
+            
+            // Regular features/enhancements
+            if ((title.startsWith('feat') || title.includes('feature') || title.includes('enhancement') || 
+                 title.startsWith('add ') || title.startsWith('add:') ||
+                 branch.startsWith('feature/') || branch.startsWith('feat/')) &&
+                !currentLabels.includes('major-enhancement')) {
+              labelsToAdd.push('enhancement');
+            }
+            
+            // Bug fixes
+            if ((title.startsWith('fix') || title.includes('bugfix') || title.includes('bug fix') ||
+                 title.includes('regression') || branch.startsWith('fix/') || branch.startsWith('bugfix/')) &&
+                !currentLabels.includes('major-bug')) {
+              labelsToAdd.push('bug');
+            }
+            
+            // Documentation
+            if (title.startsWith('docs') || title.startsWith('doc:') || 
+                branch.startsWith('docs/') || branch.startsWith('doc/')) {
+              labelsToAdd.push('documentation');
+            }
+            
+            // Chore/Maintenance
+            if (title.startsWith('chore') || title.startsWith('maint') || 
+                title.startsWith('ci:') || title.startsWith('build:') ||
+                branch.startsWith('chore/') || branch.startsWith('maint/')) {
+              labelsToAdd.push('chore');
+            }
+            
+            // Refactoring
+            if (title.startsWith('refactor') || title.includes('refactoring') ||
+                branch.startsWith('refactor/')) {
+              labelsToAdd.push('refactor');
+            }
+            
+            // Tests
+            if (title.startsWith('test') || branch.startsWith('test/')) {
+              labelsToAdd.push('tests');
+            }
+            
+            // Security
+            if (title.includes('security') || title.includes('cve-') || 
+                title.includes('vulnerability') || branch.startsWith('security/')) {
+              labelsToAdd.push('security');
+            }
+            
+            // ═══════════════════════════════════════════════════════════════
+            // Auto-approve countdown for owner/member PRs
+            // ═══════════════════════════════════════════════════════════════
+            
+            const countdownLabel = 'merge-in-3-days-without-review';
+            const hasCountdownLabel = currentLabels.some(l => l.startsWith('merge-in-'));
+            
+            // Add countdown label for trusted authors (non-draft only)
+            // OWNER = repo owner, MEMBER = org member, COLLABORATOR = added as collaborator
+            const trustedAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (trustedAssociations.includes(authorAssoc) && !isDraft && !hasCountdownLabel) {
+              labelsToAdd.push(countdownLabel);
+              console.log(`  → Adding auto-approve countdown for ${authorAssoc}`);
+            }
+            
+            // ═══════════════════════════════════════════════════════════════
+            // Apply labels
+            // ═══════════════════════════════════════════════════════════════
+            
+            // Filter out labels that already exist
+            const newLabels = labelsToAdd.filter(l => !currentLabels.includes(l));
+            
+            if (newLabels.length > 0) {
+              console.log(`  → Adding labels: ${newLabels.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: newLabels
+              });
+            } else {
+              console.log('  → No new labels to add');
+            }

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,16 @@
+﻿# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+﻿# Auto-enable squash merge for Dependabot PRs
+# GitHub will automatically merge once all required checks pass
+#
+# Uses pull_request_target so the workflow runs in the base-branch context
+# and the default GITHUB_TOKEN has write permissions (Dependabot-triggered
+# pull_request events only expose a read-only token).
+name: Dependabot Auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,41 @@
+name: PR Labels
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Run labeler
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+
+  required:
+    name: PR Labels - Required
+    runs-on: ubuntu-latest
+    if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
+    needs:
+      - label
+    steps:
+      - name: Verify required jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "label: ${{ needs.label.result }}"
+          if [ "${{ needs.label.result }}" != "success" ]; then
+            echo "::error::PR Labels failed"
+            exit 1
+          fi

--- a/.github/workflows/rebase-open-prs.yml
+++ b/.github/workflows/rebase-open-prs.yml
@@ -1,0 +1,22 @@
+﻿name: Rebase open PRs
+
+on:
+  push:
+    branches:
+      - master
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebase-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mPokornyETM/rebase-open-prs-action@v1
+        env:
+          # Use PAT to trigger subsequent workflows (security scan, etc.)
+          # Falls back to github.token if GH_TOKEN secret is not set
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        with:
+          github-token: ${{ secrets.GH_TOKEN || github.token }}
+


### PR DESCRIPTION
﻿# Summary

This PR standardizes GitHub automation (based on lockable-resources-plugin):
- Auto-enable auto-merge for all Dependabot PRs (squash) once required checks pass.
- Keep open PRs rebaseable by rebasing them after pushes to the default branch.
- Auto-label PRs (title/branch/association) + file-based labels via actions/labeler.
- Auto-approve OWNER PRs after 3 days without review (optional).
- Add Jenkins plugin incremental release workflow (maven-cd).

## Notes
- These workflows do not replace the Jenkinsfile build; CI remains defined in Jenkins.
- Auto-merge only completes when repo settings allow auto-merge and required checks pass.

## Required secrets / settings
- `MAVEN_USERNAME` + `MAVEN_TOKEN` for `cd` workflow (Jenkins plugin CD).
- Optional: `GH_TOKEN` secret to make rebase trigger downstream workflows; falls back to `github.token`.
